### PR TITLE
Add willkelly.com proof of concept site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,17 @@
 name: Deploy site to GitHub Pages
 
 # Publishes the static POC site (index.html, styles.css, app.js at repo root).
-# Runs on the default branch and on the POC branch so the site can go live
-# before the PR is merged. Auto-enables Pages on first run via configure-pages.
+#
+# ONE-TIME SETUP (required once, in the browser):
+#   Settings -> Pages -> Build and deployment -> Source: "GitHub Actions"
+# The Actions token cannot enable Pages for the first time via API, so this
+# switch must be flipped manually once. After that, every push to main (and
+# manual "Run workflow") deploys automatically.
 
 on:
   push:
     branches:
       - main
-      - claude/willkelly-poc-svibpf
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy site to GitHub Pages
+
+# Publishes the static POC site (index.html, styles.css, app.js at repo root).
+# Runs on the default branch and on the POC branch so the site can go live
+# before the PR is merged. Auto-enables Pages on first run via configure-pages.
+
+on:
+  push:
+    branches:
+      - main
+      - claude/willkelly-poc-svibpf
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/POC.md
+++ b/POC.md
@@ -1,0 +1,53 @@
+# willkelly.com — Proof of Concept
+
+A fast, dependency-free personal/consulting site for **Will Kelly** — technical
+content strategist focused on AI enablement and content operations.
+
+## What this is
+
+A single-page marketing site that turns the README bio into a real landing page,
+built around Will's signature positioning: **"Sell the diagnostic, not the solution."**
+
+The centerpiece is a working **AI & documentation readiness diagnostic** — six
+questions, an instant weighted score, and tier-specific guidance — so the site
+*demonstrates* the philosophy instead of just describing it. No email wall.
+
+## Structure
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Full landing page markup (hero, three core areas, diagnostic, products, proof, contact) |
+| `styles.css` | Design system + responsive layout, no framework |
+| `app.js` | Mobile nav + the interactive readiness diagnostic |
+| `README.md` | Will's existing account bio (unchanged) |
+
+## Sections
+
+1. **Hero** — positioning line, dual CTA, track-record stats
+2. **What I build** — the three core areas
+3. **Live diagnostic** — the interactive scorecard (the differentiator)
+4. **Products** — ContentOps / Gumroad / Notion catalog
+5. **Philosophy** — pull quote
+6. **Proof** — Docker, GDIT, CDW, independent
+7. **Contact** — email, LinkedIn, newsletter, Medium
+
+## Run it
+
+It's static — just open `index.html`, or serve locally:
+
+```bash
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+## Deploy
+
+Zero build step. Works as-is on GitHub Pages, Netlify, Vercel, or Cloudflare Pages.
+Point the `willkelly.com` domain at whichever host you prefer.
+
+## Notes / next steps
+
+- Diagnostic uses a demonstration scoring model; wire it to the production
+  maturity rubric and (optionally) capture leads on the results step.
+- Swap the CTA `mailto:` for a scheduling link (Cal.com / Calendly).
+- Add real Gumroad / Notion Marketplace product links when live.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,261 @@
+/* Will Kelly — willkelly.com POC
+   Vanilla JS: mobile nav, footer year, and the AI/content-ops readiness diagnostic. */
+
+(function () {
+  'use strict';
+
+  /* ---------- Footer year ---------- */
+  var yearEl = document.getElementById('year');
+  if (yearEl) yearEl.textContent = String(new Date().getFullYear());
+
+  /* ---------- Mobile nav ---------- */
+  var toggle = document.querySelector('.nav-toggle');
+  var links = document.getElementById('nav-links');
+  if (toggle && links) {
+    toggle.addEventListener('click', function () {
+      var open = links.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', String(open));
+    });
+    links.addEventListener('click', function (e) {
+      if (e.target.tagName === 'A') {
+        links.classList.remove('open');
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  /* ---------- Diagnostic ----------
+     Each question offers 4 options scored 0..3. Max raw = questions * 3.
+     Normalized to 0..100. Tiers drive tailored guidance — mirroring the
+     "sell the diagnostic" positioning: honest read first, plan second. */
+
+  var QUESTIONS = [
+    {
+      id: 'source',
+      text: 'Where does your documentation actually live?',
+      opts: [
+        { label: 'Scattered across tools & people', v: 0 },
+        { label: 'A wiki nobody trusts', v: 1 },
+        { label: 'Mostly one system, some drift', v: 2 },
+        { label: 'One governed source of truth', v: 3 }
+      ]
+    },
+    {
+      id: 'ownership',
+      text: 'Who owns content quality and freshness?',
+      opts: [
+        { label: 'No one, really', v: 0 },
+        { label: 'Whoever complains loudest', v: 1 },
+        { label: 'A part-time champion', v: 2 },
+        { label: 'Clear owners with SLAs', v: 3 }
+      ]
+    },
+    {
+      id: 'metadata',
+      text: 'How structured is your content metadata?',
+      opts: [
+        { label: 'What metadata?', v: 0 },
+        { label: 'Titles and folders', v: 1 },
+        { label: 'Tags, owners, review dates', v: 2 },
+        { label: 'Governed taxonomy + lifecycle', v: 3 }
+      ]
+    },
+    {
+      id: 'ai',
+      text: 'How is your team using AI on this content today?',
+      opts: [
+        { label: 'Banned or ignored', v: 0 },
+        { label: 'Ad-hoc copy/paste into chatbots', v: 1 },
+        { label: 'A few shared prompts', v: 2 },
+        { label: 'Governed assistants on trusted sources', v: 3 }
+      ]
+    },
+    {
+      id: 'debt',
+      text: 'Can you quantify your documentation debt?',
+      opts: [
+        { label: 'No idea how bad it is', v: 0 },
+        { label: 'We know it’s bad', v: 1 },
+        { label: 'Rough sense of hotspots', v: 2 },
+        { label: 'Measured, prioritized backlog', v: 3 }
+      ]
+    },
+    {
+      id: 'pilot',
+      text: 'What happens after an AI pilot succeeds?',
+      opts: [
+        { label: 'It quietly dies', v: 0 },
+        { label: 'Endless "next pilot"', v: 1 },
+        { label: 'Partial rollout, no standard', v: 2 },
+        { label: 'Operationalized with governance', v: 3 }
+      ]
+    }
+  ];
+
+  var TIERS = [
+    {
+      min: 0, max: 39,
+      tier: 'Pre-foundational',
+      color: '#d5533f',
+      headline: 'You’re fighting a data problem with willpower.',
+      summary: 'Right now the pain is real but invisible — no source of truth, no owners, no way to size the debt. AI on top of this amplifies the mess. The good news: this is exactly where a diagnostic pays for itself fastest.',
+      actions: [
+        'Establish a single source of truth before touching AI tooling',
+        'Run a documentation debt audit to make the cost visible to leadership',
+        'Name owners and basic review SLAs — governance beats another tool'
+      ]
+    },
+    {
+      min: 40, max: 69,
+      tier: 'Emerging',
+      color: '#e0a021',
+      headline: 'Real foundations, uneven discipline.',
+      summary: 'You’ve got pockets of structure and some AI experimentation, but drift and inconsistent ownership will cap how far AI can safely go. The work now is standardizing what already works and killing the "endless pilot" loop.',
+      actions: [
+        'Tighten metadata: tags, owners, and review dates as non-negotiables',
+        'Codify shared prompts into governed assistants on trusted sources',
+        'Define what "operationalized" means so pilots have a finish line'
+      ]
+    },
+    {
+      min: 70, max: 89,
+      tier: 'Operationalizing',
+      color: '#1f9d6b',
+      headline: 'You’re past pilots — now scale the system.',
+      summary: 'Governance, ownership, and structured content are mostly in place. The opportunity is compounding: knowledge graphs, documentation-health agents, and repeatable Claude blueprints that turn your content ops into a durable advantage.',
+      actions: [
+        'Layer documentation-health agents onto your governed sources',
+        'Package internal playbooks so wins repeat across teams',
+        'Measure freshness and reuse as ongoing operational metrics'
+      ]
+    },
+    {
+      min: 90, max: 100,
+      tier: 'Exemplary',
+      color: '#1f9d6b',
+      headline: 'This is the model others should copy.',
+      summary: 'Single source of truth, clear ownership, governed AI, measured debt. You don’t need rescue — you need leverage: turning your operating model into productized IP and a story that lands with executive buyers.',
+      actions: [
+        'Externalize your methodology as a repeatable framework',
+        'Use case-study frameworks to capture proof even without hard metrics',
+        'Stress-test governance against new AI use cases before they arrive'
+      ]
+    }
+  ];
+
+  var listEl = document.getElementById('questions');
+  var app = document.getElementById('diagnostic-app');
+  var form = document.getElementById('diagnostic-form');
+  var resultEl = document.getElementById('result');
+  var scoreBtn = document.getElementById('scoreBtn');
+  var resetBtn = document.getElementById('resetBtn');
+
+  if (!listEl || !form) return; // diagnostic markup absent; nothing to wire
+
+  // Render questions
+  QUESTIONS.forEach(function (q, qi) {
+    var li = document.createElement('li');
+    li.className = 'q-item';
+
+    var p = document.createElement('p');
+    p.className = 'q-text';
+    p.innerHTML = '<span class="q-num">' + (qi + 1) + '</span><span>' + q.text + '</span>';
+    li.appendChild(p);
+
+    var opts = document.createElement('div');
+    opts.className = 'q-opts';
+    q.opts.forEach(function (o, oi) {
+      var id = 'q' + qi + '_' + oi;
+      var input = document.createElement('input');
+      input.type = 'radio';
+      input.name = q.id;
+      input.id = id;
+      input.value = String(o.v);
+
+      var label = document.createElement('label');
+      label.setAttribute('for', id);
+      label.textContent = o.label;
+
+      opts.appendChild(input);
+      opts.appendChild(label);
+    });
+    li.appendChild(opts);
+    listEl.appendChild(li);
+  });
+
+  function tierFor(score) {
+    for (var i = 0; i < TIERS.length; i++) {
+      if (score >= TIERS[i].min && score <= TIERS[i].max) return TIERS[i];
+    }
+    return TIERS[TIERS.length - 1];
+  }
+
+  function computeScore() {
+    var raw = 0, answered = 0;
+    QUESTIONS.forEach(function (q) {
+      var checked = form.querySelector('input[name="' + q.id + '"]:checked');
+      if (checked) { raw += Number(checked.value); answered++; }
+    });
+    return { answered: answered, pct: Math.round((raw / (QUESTIONS.length * 3)) * 100) };
+  }
+
+  function showResult() {
+    var res = computeScore();
+
+    if (res.answered < QUESTIONS.length) {
+      // Gentle nudge; scroll to first unanswered question.
+      var firstUnanswered = QUESTIONS.find(function (q) {
+        return !form.querySelector('input[name="' + q.id + '"]:checked');
+      });
+      if (firstUnanswered) {
+        var node = form.querySelector('input[name="' + firstUnanswered.id + '"]');
+        if (node && node.closest('.q-item')) {
+          node.closest('.q-item').style.outline = '2px solid var(--accent)';
+          node.closest('.q-item').style.outlineOffset = '3px';
+          node.closest('.q-item').scrollIntoView({ behavior: 'smooth', block: 'center' });
+          setTimeout(function () { node.closest('.q-item').style.outline = 'none'; }, 1600);
+        }
+      }
+      scoreBtn.textContent = 'Answer all six to score (' + res.answered + '/' + QUESTIONS.length + ')';
+      setTimeout(function () { scoreBtn.textContent = 'See my readiness score'; }, 1800);
+      return;
+    }
+
+    var t = tierFor(res.pct);
+
+    document.getElementById('scoreValue').textContent = String(res.pct);
+    document.getElementById('scoreTier').textContent = t.tier;
+    document.getElementById('scoreTier').style.color = t.color;
+    document.getElementById('resultHeadline').textContent = t.headline;
+    document.getElementById('resultSummary').textContent = t.summary;
+
+    var ul = document.getElementById('resultActions');
+    ul.innerHTML = '';
+    t.actions.forEach(function (a) {
+      var li = document.createElement('li');
+      li.textContent = a;
+      ul.appendChild(li);
+    });
+
+    resultEl.hidden = false;
+    if (app) app.setAttribute('data-state', 'result');
+
+    // Animate gauge after paint.
+    requestAnimationFrame(function () {
+      var fill = document.getElementById('gaugeFill');
+      fill.style.width = res.pct + '%';
+      fill.style.background = t.color;
+    });
+
+    resultEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  scoreBtn.addEventListener('click', showResult);
+
+  form.addEventListener('reset', function () {
+    resultEl.hidden = true;
+    if (app) app.removeAttribute('data-state');
+    var fill = document.getElementById('gaugeFill');
+    if (fill) fill.style.width = '0';
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Will Kelly — AI Enablement &amp; Content Operations</title>
+  <meta name="description" content="Technical content strategist focused on AI enablement. Diagnostic frameworks, productized consulting IP, and Claude-powered workflows for enterprise knowledge systems." />
+  <meta name="author" content="Will Kelly" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Will Kelly — AI Enablement &amp; Content Operations" />
+  <meta property="og:description" content="Sell the diagnostic, not the solution. Frameworks and Claude-powered workflows that help enterprises fix broken documentation and adopt AI pragmatically." />
+  <meta property="og:url" content="https://willkelly.com" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='20' fill='%230b1220'/%3E%3Ctext x='50' y='68' font-size='58' font-family='Georgia,serif' fill='%23ffb020' text-anchor='middle'%3EWK%3C/text%3E%3C/svg%3E" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header" id="top">
+    <nav class="nav" aria-label="Primary">
+      <a class="brand" href="#top">
+        <span class="brand-mark" aria-hidden="true">WK</span>
+        <span class="brand-name">Will Kelly</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-controls="nav-links" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="#work">What I build</a></li>
+        <li><a href="#diagnostic">Diagnostic</a></li>
+        <li><a href="#products">Products</a></li>
+        <li><a href="#proof">Proof</a></li>
+        <li><a class="nav-cta" href="#contact">Work with me</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">AI enablement &middot; Content operations &middot; Northern Virginia</p>
+        <h1>Sell the diagnostic,<br /><span class="accent">not the solution.</span></h1>
+        <p class="lede">
+          I build diagnostic frameworks, productized consulting IP, and Claude-powered
+          workflows that help enterprise teams fix broken documentation, adopt AI
+          pragmatically, and operationalize knowledge at scale &mdash; without the vendor theater.
+        </p>
+        <div class="hero-cta">
+          <a class="btn btn-primary" href="#diagnostic">Take the 2-minute AI readiness check</a>
+          <a class="btn btn-ghost" href="#contact">Book a working session</a>
+        </div>
+        <ul class="hero-stats" aria-label="Track record">
+          <li><strong>15+</strong><span>years in enterprise tech content</span></li>
+          <li><strong>40%</strong><span>asset reuse lift at Docker</span></li>
+          <li><strong>15+</strong><span>governance deployments</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- WHAT I BUILD -->
+    <section id="work" class="section">
+      <div class="wrap">
+        <header class="section-head">
+          <p class="kicker">What I build</p>
+          <h2>Three core areas, one operating principle</h2>
+          <p class="section-sub">
+            AI adoption fails when organizations treat it like a prompt experiment. The real
+            opportunity is repeatable systems that combine AI, documentation, structured
+            workflows, and operational discipline.
+          </p>
+        </header>
+
+        <div class="cards">
+          <article class="card">
+            <div class="card-icon" aria-hidden="true">◎</div>
+            <h3>AI enablement &amp; diagnostics</h3>
+            <p>
+              Structured assessments that surface AI readiness gaps, adoption blockers, and
+              governance friction &mdash; grounded in 15+ years of enterprise experience, not hype.
+            </p>
+          </article>
+          <article class="card">
+            <div class="card-icon" aria-hidden="true">▤</div>
+            <h3>Productized consulting IP</h3>
+            <p>
+              Documentation debt audits, AI readiness checklists, Notion migration playbooks,
+              and maturity scorecards &mdash; packaged as repeatable, sellable assets.
+            </p>
+          </article>
+          <article class="card">
+            <div class="card-icon" aria-hidden="true">⌘</div>
+            <h3>Claude blueprints &amp; prompts</h3>
+            <p>
+              System prompts, knowledge-graph builders, documentation-health agents, and content
+              pipeline automations designed for practitioners &mdash; not marketers.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- INTERACTIVE DIAGNOSTIC -->
+    <section id="diagnostic" class="section section-alt">
+      <div class="wrap">
+        <header class="section-head">
+          <p class="kicker">Live diagnostic</p>
+          <h2>AI &amp; documentation readiness check</h2>
+          <p class="section-sub">
+            A taste of how I work: answer six questions and get an instant, honest read on where
+            your content operation stands &mdash; and what to fix first. No email wall.
+          </p>
+        </header>
+
+        <div class="diagnostic" id="diagnostic-app" data-diagnostic>
+          <form class="diagnostic-form" id="diagnostic-form">
+            <ol class="questions" id="questions"><!-- injected by app.js --></ol>
+            <div class="diagnostic-actions">
+              <button type="button" class="btn btn-primary" id="scoreBtn">See my readiness score</button>
+              <button type="reset" class="btn btn-ghost" id="resetBtn">Reset</button>
+            </div>
+          </form>
+
+          <div class="diagnostic-result" id="result" hidden aria-live="polite">
+            <div class="gauge">
+              <div class="gauge-num"><span id="scoreValue">0</span><small>/ 100</small></div>
+              <div class="gauge-bar"><div class="gauge-fill" id="gaugeFill"></div></div>
+              <p class="gauge-tier" id="scoreTier"></p>
+            </div>
+            <div class="result-body">
+              <h3 id="resultHeadline">Your readiness read</h3>
+              <p id="resultSummary"></p>
+              <ul id="resultActions" class="result-actions"></ul>
+              <a class="btn btn-primary" href="#contact">Turn this into a plan &rarr;</a>
+            </div>
+          </div>
+        </div>
+        <p class="fine-print">
+          Prototype scoring model for demonstration. The production diagnostic maps to a
+          weighted content-ops maturity rubric refined across client engagements.
+        </p>
+      </div>
+    </section>
+
+    <!-- PRODUCTS -->
+    <section id="products" class="section">
+      <div class="wrap">
+        <header class="section-head">
+          <p class="kicker">Featured frameworks &amp; products</p>
+          <h2>Tools for people who actually do the work</h2>
+        </header>
+
+        <div class="product-grid">
+          <div class="product-col">
+            <h3 class="col-title">Open source &mdash; ContentOps</h3>
+            <ul class="product-list">
+              <li><span>30-60-90-Day Content Ops Plan</span><em>Playbook</em></li>
+              <li><span>GTM Content Ops Accelerator</span><em>Framework</em></li>
+              <li><span>Content Lifecycle Checklist</span><em>Checklist</em></li>
+              <li><span>Case Study Framework</span><em>Template</em></li>
+              <li><span>Custom GPT governance playbook</span><em>Governance</em></li>
+            </ul>
+          </div>
+          <div class="product-col">
+            <h3 class="col-title">Gumroad &mdash; productized IP</h3>
+            <ul class="product-list">
+              <li><span>AI pilot readiness checklist</span><em>Diagnostic</em></li>
+              <li><span>Documentation debt audit framework</span><em>Audit</em></li>
+              <li><span>Confluence &rarr; Notion pre-flight</span><em>Migration</em></li>
+              <li><span>Claude Project blueprint packs</span><em>Blueprints</em></li>
+              <li><span>Content ops maturity scorecard</span><em>React tool</em></li>
+            </ul>
+          </div>
+          <div class="product-col">
+            <h3 class="col-title">Notion Marketplace</h3>
+            <ul class="product-list">
+              <li><span>Content operations hub</span><em>Template</em></li>
+              <li><span>Editorial calendar &amp; brief builder</span><em>Template</em></li>
+              <li><span>Consulting deliverable tracker</span><em>Template</em></li>
+              <li><span>Client knowledge graph</span><em>Template</em></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- PHILOSOPHY -->
+    <section class="section section-quote">
+      <div class="wrap narrow">
+        <blockquote>
+          <p>
+            &ldquo;Documentation debt is often a <strong>data problem</strong> masquerading as a
+            technology problem. The fix isn&rsquo;t a new tool &mdash; it&rsquo;s governance, metadata
+            discipline, and workflows that force prioritization.&rdquo;
+          </p>
+          <cite>Pattern recognition beats vendor theater.</cite>
+        </blockquote>
+      </div>
+    </section>
+
+    <!-- PROOF -->
+    <section id="proof" class="section section-alt">
+      <div class="wrap">
+        <header class="section-head">
+          <p class="kicker">Experience &amp; proof points</p>
+          <h2>Fifteen years fixing content dysfunction</h2>
+        </header>
+
+        <div class="timeline">
+          <div class="timeline-item">
+            <span class="timeline-org">Docker</span>
+            <p>Built GTM content operations; consolidated fragmented output across three teams into a single pipeline, lifting asset reuse <strong>40%</strong>.</p>
+          </div>
+          <div class="timeline-item">
+            <span class="timeline-org">GDIT / CSRA</span>
+            <p>Content strategy for B2G / federal IT &mdash; technical messaging in high-compliance environments.</p>
+          </div>
+          <div class="timeline-item">
+            <span class="timeline-org">CDW</span>
+            <p>Technical writing and architecture, plus dozens of trade-publication bylines.</p>
+          </div>
+          <div class="timeline-item">
+            <span class="timeline-org">Independent</span>
+            <p>Proprietary CTRL+ALT+SharePoint governance methodology across <strong>15+</strong> deployments; Confluence-to-Notion migrations and editorial governance.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CONTACT -->
+    <section id="contact" class="section section-cta">
+      <div class="wrap narrow center">
+        <p class="kicker light">Current focus</p>
+        <h2>Building the proof points &mdash; and taking on fractional work</h2>
+        <p class="section-sub light">
+          Actively consulting on content ops maturity, documentation debt, and AI readiness.
+          If you need to move past pilot projects into sustainable practice, let&rsquo;s talk.
+        </p>
+        <div class="hero-cta center">
+          <a class="btn btn-primary" href="mailto:will@willkelly.com?subject=Working%20session%20inquiry">Email will@willkelly.com</a>
+          <a class="btn btn-ghost" href="https://linkedin.com/in/willkelly" target="_blank" rel="noopener">Connect on LinkedIn</a>
+        </div>
+        <div class="links-row">
+          <a href="https://willkelly.substack.com" target="_blank" rel="noopener">Newsletter</a>
+          <a href="https://willkelly.medium.com" target="_blank" rel="noopener">Medium</a>
+          <a href="https://github.com/will-kelly/ContentOps" target="_blank" rel="noopener">ContentOps repo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer-inner">
+      <p>&copy; <span id="year"></span> Will Kelly &middot; Northern Virginia</p>
+      <p class="footer-note">Anti-vendor-theater since day one.</p>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,266 @@
+/* Will Kelly — willkelly.com POC
+   Dependency-free. Design tokens, layout, components. */
+
+:root {
+  --ink: #0b1220;
+  --ink-2: #131c2e;
+  --paper: #f7f8fb;
+  --paper-2: #ffffff;
+  --muted: #5b6675;
+  --line: #e4e8ef;
+  --accent: #ff8c1a;
+  --accent-2: #ffb020;
+  --accent-ink: #7a3d00;
+  --good: #1f9d6b;
+  --warn: #e0a021;
+  --bad: #d5533f;
+  --radius: 14px;
+  --radius-sm: 9px;
+  --shadow: 0 10px 30px -12px rgba(11, 18, 32, .25);
+  --wrap: 1120px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --serif: Georgia, "Times New Roman", serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { max-width: var(--wrap); margin: 0 auto; padding: 0 24px; }
+.narrow { max-width: 760px; }
+.center { text-align: center; }
+
+img { max-width: 100%; }
+
+a { color: inherit; }
+
+.skip-link {
+  position: absolute; left: -999px; top: 0; background: var(--ink); color: #fff;
+  padding: 10px 16px; z-index: 100; border-radius: 0 0 8px 0;
+}
+.skip-link:focus { left: 0; }
+
+/* ---------- Buttons ---------- */
+.btn {
+  display: inline-block; font-weight: 600; font-size: 15px; line-height: 1;
+  padding: 14px 22px; border-radius: 999px; text-decoration: none; cursor: pointer;
+  border: 1.5px solid transparent; transition: transform .12s ease, box-shadow .2s ease, background .2s ease;
+}
+.btn:active { transform: translateY(1px); }
+.btn-primary {
+  background: linear-gradient(180deg, var(--accent-2), var(--accent));
+  color: #241100; box-shadow: 0 8px 20px -8px rgba(255, 140, 26, .7);
+}
+.btn-primary:hover { box-shadow: 0 12px 26px -8px rgba(255, 140, 26, .85); }
+.btn-ghost { background: transparent; border-color: var(--line); color: var(--ink); }
+.btn-ghost:hover { border-color: var(--ink); }
+
+/* ---------- Header / Nav ---------- */
+.site-header {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(247, 248, 251, .82);
+  backdrop-filter: saturate(140%) blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.nav {
+  max-width: var(--wrap); margin: 0 auto; padding: 14px 24px;
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+}
+.brand { display: flex; align-items: center; gap: 10px; text-decoration: none; font-weight: 700; }
+.brand-mark {
+  display: grid; place-items: center; width: 34px; height: 34px; border-radius: 9px;
+  background: var(--ink); color: var(--accent-2); font-family: var(--serif); font-size: 16px;
+}
+.brand-name { color: var(--ink); letter-spacing: -.01em; }
+.nav-links { display: flex; align-items: center; gap: 26px; list-style: none; margin: 0; padding: 0; }
+.nav-links a { text-decoration: none; color: var(--muted); font-size: 15px; font-weight: 500; }
+.nav-links a:hover { color: var(--ink); }
+.nav-cta {
+  color: var(--ink) !important; border: 1.5px solid var(--line); padding: 9px 16px; border-radius: 999px;
+}
+.nav-cta:hover { border-color: var(--ink); }
+.nav-toggle { display: none; background: none; border: 0; cursor: pointer; padding: 8px; }
+.nav-toggle span { display: block; width: 22px; height: 2px; background: var(--ink); margin: 4px 0; border-radius: 2px; transition: .2s; }
+
+/* ---------- Hero ---------- */
+.hero {
+  position: relative; overflow: hidden;
+  background: radial-gradient(1200px 500px at 80% -10%, #1b2740 0, transparent 60%),
+              linear-gradient(180deg, var(--ink), var(--ink-2));
+  color: #eaf0f8; padding: 92px 0 84px;
+}
+.hero .eyebrow {
+  text-transform: uppercase; letter-spacing: .14em; font-size: 12.5px; font-weight: 600;
+  color: var(--accent-2); margin: 0 0 18px;
+}
+.hero h1 {
+  font-family: var(--serif); font-weight: 700; font-size: clamp(38px, 6.5vw, 66px);
+  line-height: 1.03; letter-spacing: -.02em; margin: 0 0 22px;
+}
+.hero h1 .accent { color: var(--accent-2); }
+.lede { font-size: clamp(17px, 2.2vw, 20px); color: #c3ccdb; max-width: 640px; margin: 0 0 30px; }
+.hero-cta { display: flex; flex-wrap: wrap; gap: 14px; }
+.hero-cta.center { justify-content: center; }
+.hero-stats {
+  display: flex; flex-wrap: wrap; gap: 40px; list-style: none; margin: 52px 0 0; padding: 34px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, .12);
+}
+.hero-stats li { display: flex; flex-direction: column; }
+.hero-stats strong { font-family: var(--serif); font-size: 34px; color: #fff; line-height: 1; }
+.hero-stats span { font-size: 13.5px; color: #9aa6b8; margin-top: 6px; max-width: 150px; }
+
+/* ---------- Sections ---------- */
+.section { padding: 84px 0; }
+.section-alt { background: var(--paper-2); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.section-head { max-width: 720px; margin: 0 0 44px; }
+.kicker {
+  text-transform: uppercase; letter-spacing: .14em; font-size: 12.5px; font-weight: 700;
+  color: var(--accent); margin: 0 0 12px;
+}
+.kicker.light { color: var(--accent-2); }
+.section h2 {
+  font-family: var(--serif); font-size: clamp(27px, 4vw, 40px); line-height: 1.1;
+  letter-spacing: -.02em; margin: 0 0 16px;
+}
+.section-sub { font-size: 17px; color: var(--muted); margin: 0; }
+.section-sub.light { color: #c3ccdb; }
+
+/* ---------- Cards ---------- */
+.cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.card {
+  background: var(--paper-2); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 30px 26px; box-shadow: var(--shadow); transition: transform .16s ease;
+}
+.card:hover { transform: translateY(-4px); }
+.card-icon {
+  width: 46px; height: 46px; border-radius: 12px; display: grid; place-items: center;
+  background: linear-gradient(180deg, #fff2e2, #ffe4c6); color: var(--accent); font-size: 22px; margin-bottom: 16px;
+}
+.card h3 { font-size: 19px; margin: 0 0 10px; letter-spacing: -.01em; }
+.card p { margin: 0; color: var(--muted); font-size: 15.5px; }
+
+/* ---------- Diagnostic ---------- */
+.diagnostic {
+  display: grid; grid-template-columns: 1.15fr .85fr; gap: 30px; align-items: start;
+  background: var(--paper); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 30px; box-shadow: var(--shadow);
+}
+.diagnostic[data-state="result"] { grid-template-columns: 1fr 1fr; }
+.questions { list-style: none; counter-reset: q; margin: 0; padding: 0; display: grid; gap: 18px; }
+.q-item { border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 16px 18px; background: var(--paper-2); }
+.q-text { font-weight: 600; font-size: 15.5px; margin: 0 0 12px; display: flex; gap: 10px; }
+.q-text .q-num {
+  flex: 0 0 auto; width: 22px; height: 22px; border-radius: 6px; background: var(--ink); color: var(--accent-2);
+  font-size: 12px; display: grid; place-items: center; font-family: var(--serif);
+}
+.q-opts { display: flex; flex-wrap: wrap; gap: 8px; }
+.q-opts label {
+  font-size: 13.5px; padding: 8px 13px; border: 1.5px solid var(--line); border-radius: 999px;
+  cursor: pointer; color: var(--muted); background: #fff; transition: .14s; user-select: none;
+}
+.q-opts input { position: absolute; opacity: 0; width: 0; height: 0; }
+.q-opts label:hover { border-color: var(--accent); color: var(--ink); }
+.q-opts input:checked + label,
+.q-opts label.is-checked {
+  background: var(--ink); color: #fff; border-color: var(--ink);
+}
+.q-opts input:focus-visible + label { outline: 2px solid var(--accent); outline-offset: 2px; }
+.diagnostic-actions { display: flex; gap: 12px; margin-top: 24px; }
+
+.diagnostic-result {
+  background: var(--paper-2); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 26px; align-self: stretch;
+}
+.gauge { text-align: center; padding-bottom: 20px; border-bottom: 1px solid var(--line); margin-bottom: 20px; }
+.gauge-num { font-family: var(--serif); font-size: 56px; line-height: 1; color: var(--ink); }
+.gauge-num small { font-size: 18px; color: var(--muted); margin-left: 4px; }
+.gauge-bar { height: 10px; background: var(--line); border-radius: 999px; overflow: hidden; margin: 16px 0 12px; }
+.gauge-fill { height: 100%; width: 0; border-radius: 999px; background: var(--bad); transition: width .9s cubic-bezier(.2,.8,.2,1), background .4s; }
+.gauge-tier { font-weight: 700; margin: 0; font-size: 15px; letter-spacing: .02em; }
+.result-body h3 { font-size: 20px; margin: 0 0 10px; font-family: var(--serif); }
+.result-body > p { color: var(--muted); font-size: 15px; margin: 0 0 16px; }
+.result-actions { list-style: none; margin: 0 0 22px; padding: 0; display: grid; gap: 10px; }
+.result-actions li {
+  font-size: 14.5px; padding-left: 26px; position: relative; color: var(--ink);
+}
+.result-actions li::before {
+  content: "→"; position: absolute; left: 0; top: 0; color: var(--accent); font-weight: 700;
+}
+.fine-print { font-size: 12.5px; color: var(--muted); margin: 18px 2px 0; }
+
+/* ---------- Products ---------- */
+.product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 26px; }
+.col-title { font-size: 14px; text-transform: uppercase; letter-spacing: .06em; color: var(--accent); margin: 0 0 14px; }
+.product-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 2px; }
+.product-list li {
+  display: flex; justify-content: space-between; align-items: center; gap: 12px;
+  padding: 13px 2px; border-bottom: 1px solid var(--line); font-size: 15px;
+}
+.product-list em {
+  font-style: normal; font-size: 11.5px; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--muted); background: var(--paper); border: 1px solid var(--line); padding: 3px 8px; border-radius: 999px; white-space: nowrap;
+}
+
+/* ---------- Quote ---------- */
+.section-quote { background: var(--ink); color: #eaf0f8; }
+.section-quote blockquote { margin: 0; }
+.section-quote p {
+  font-family: var(--serif); font-size: clamp(22px, 3.4vw, 32px); line-height: 1.3; margin: 0 0 18px;
+}
+.section-quote strong { color: var(--accent-2); }
+.section-quote cite {
+  font-style: normal; color: var(--accent-2); font-weight: 700; letter-spacing: .02em;
+  text-transform: uppercase; font-size: 13px;
+}
+
+/* ---------- Timeline ---------- */
+.timeline { display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; }
+.timeline-item {
+  background: var(--paper); border: 1px solid var(--line); border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm); padding: 22px 24px;
+}
+.timeline-org { display: block; font-weight: 700; font-size: 16px; margin-bottom: 8px; }
+.timeline-item p { margin: 0; color: var(--muted); font-size: 15px; }
+
+/* ---------- CTA ---------- */
+.section-cta {
+  background: radial-gradient(900px 400px at 20% 0%, #1b2740 0, transparent 60%),
+              linear-gradient(180deg, var(--ink-2), var(--ink));
+  color: #eaf0f8;
+}
+.links-row { display: flex; gap: 26px; justify-content: center; margin-top: 30px; flex-wrap: wrap; }
+.links-row a { color: #9aa6b8; text-decoration: none; font-size: 14.5px; border-bottom: 1px solid transparent; }
+.links-row a:hover { color: #fff; border-color: var(--accent-2); }
+
+/* ---------- Footer ---------- */
+.site-footer { background: var(--ink); color: #8593a8; padding: 30px 0; }
+.footer-inner { display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; }
+.site-footer p { margin: 0; font-size: 13.5px; }
+.footer-note { color: var(--accent-2); }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .cards, .product-grid { grid-template-columns: 1fr; }
+  .diagnostic, .diagnostic[data-state="result"] { grid-template-columns: 1fr; }
+  .timeline { grid-template-columns: 1fr; }
+  .nav-toggle { display: block; }
+  .nav-links {
+    position: absolute; top: 63px; left: 0; right: 0; flex-direction: column; align-items: flex-start;
+    gap: 4px; background: var(--paper-2); border-bottom: 1px solid var(--line); padding: 12px 24px 20px;
+    display: none;
+  }
+  .nav-links.open { display: flex; }
+  .nav-links li { width: 100%; }
+  .nav-links a { display: block; padding: 10px 0; width: 100%; }
+  .hero-stats { gap: 28px; }
+}


### PR DESCRIPTION
## Summary

A fast, dependency-free proof of concept for **willkelly.com** — a consulting landing page built from the account bio in `README.md`. No framework, no build step; deploys as-is to GitHub Pages / Vercel / Netlify.

The site is organized around the signature positioning **"Sell the diagnostic, not the solution."** Its centerpiece is a working **AI & documentation readiness diagnostic**: six questions, an instant weighted 0–100 score, a color-coded gauge, and tier-specific guidance (Pre-foundational → Emerging → Operationalizing → Exemplary). It *demonstrates* the philosophy rather than just describing it — and there's no email wall, matching the anti-vendor-theater stance.

## What's included

| File | Purpose |
|------|---------|
| `index.html` | Full landing page (hero, three core areas, diagnostic, product catalog, proof, contact) |
| `styles.css` | Design system + responsive layout, no framework |
| `app.js` | Mobile nav + the interactive readiness diagnostic |
| `POC.md` | How to run/deploy + suggested next steps |
| `.github/workflows/pages.yml` | Deploys the static site to GitHub Pages (auto-enables on first run) |

## Sections

1. **Hero** — positioning line, dual CTA, track-record stats
2. **What I build** — the three core areas
3. **Live diagnostic** — the interactive scorecard (the differentiator)
4. **Products** — ContentOps / Gumroad / Notion catalog
5. **Philosophy** — pull quote
6. **Proof** — Docker, GDIT, CDW, independent
7. **Contact** — email, LinkedIn, newsletter, Medium

## Verification

Rendered headless (Chromium) with no JS/console errors. The diagnostic was exercised end-to-end: chips highlight on select, the score computes and branches to the correct tier, and tier-specific guidance populates.

## Notes / next steps

- The diagnostic uses a demonstration scoring model; wire it to the production maturity rubric (and optionally capture leads on the results step).
- Swap the contact `mailto:` for a scheduling link (Cal.com / Calendly).
- Add live Gumroad / Notion Marketplace product URLs.
- `README.md` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015W1DT1q4onMbPxuHn7nYuW)_